### PR TITLE
Fix software SPI

### DIFF
--- a/AD985X.cpp
+++ b/AD985X.cpp
@@ -45,7 +45,7 @@ AD9850::AD9850(uint8_t slaveSelect, uint8_t resetPin, uint8_t FQUDPin, uint8_t s
   _fqud    = FQUDPin;
   _hwSPI   = false;
   _mySPI   = NULL;
-  _dataOut = 0;
+  _dataOut = spiData;
   _clock   = spiClock;
 }
 

--- a/examples/AD9850_demo/AD9850_demo.ino
+++ b/examples/AD9850_demo/AD9850_demo.ino
@@ -23,7 +23,7 @@ void setup()
   Serial.print("AD985X_LIB_VERSION: \t");
   Serial.println(AD985X_LIB_VERSION);
 
-  SPI.begin();
+  // SPI.begin();  //  HW SPI
 
   help();
 

--- a/examples/AD9850_demo_float/AD9850_demo_float.ino
+++ b/examples/AD9850_demo_float/AD9850_demo_float.ino
@@ -23,7 +23,7 @@ void setup()
   Serial.print("AD985X_LIB_VERSION: \t");
   Serial.println(AD985X_LIB_VERSION);
 
-  SPI.begin();
+  // SPI.begin();  //  HW SPI
 
   freqGen.begin();
   freqGen.powerUp();

--- a/examples/AD9850_multi_sync/AD9850_multi_sync.ino
+++ b/examples/AD9850_multi_sync/AD9850_multi_sync.ino
@@ -37,7 +37,7 @@ void setup()
   Serial.print("AD985X_LIB_VERSION: \t");
   Serial.println(AD985X_LIB_VERSION);
 
-  SPI.begin();
+  // SPI.begin();  //  HW SPI
 
   //  initialize the devices
   freqGen0.begin();

--- a/examples/AD9851_demo/AD9851_demo.ino
+++ b/examples/AD9851_demo/AD9851_demo.ino
@@ -8,7 +8,8 @@
 #include "AD985X.h"
 
 
-AD9851 freqGen(10, 9, 8, 7, 6);
+AD9851 freqGen(10, 9, 8, 7, 6);  //  SW SPI
+//  AD9851 freqGen(10, 9, 8, &SPI, 6);  //  HW SPI
 
 uint32_t freq = 0;
 uint32_t prev = 0;
@@ -22,7 +23,7 @@ void setup()
   Serial.print("AD985X_LIB_VERSION: \t");
   Serial.println(AD985X_LIB_VERSION);
 
-  SPI.begin();
+  // SPI.begin();  //  HW SPI
 
   freqGen.begin();
   freqGen.powerUp();

--- a/examples/AD9851_demo_2/AD9851_demo_2.ino
+++ b/examples/AD9851_demo_2/AD9851_demo_2.ino
@@ -8,7 +8,8 @@
 #include "AD985X.h"
 
 
-AD9851 freqGen(10, 9, 8, 7, 6);
+AD9851 freqGen(10, 9, 8, 7, 6);  //  SW SPI
+//  AD9851 freqGen(10, 9, 8, &SPI, 6);  //  HW SPI
 
 uint32_t freq = 0;
 uint32_t prev = 0;
@@ -22,7 +23,7 @@ void setup()
   Serial.print("AD985X_LIB_VERSION: \t");
   Serial.println(AD985X_LIB_VERSION);
 
-  SPI.begin();
+  // SPI.begin();  //  HW SPI
 
   freqGen.begin();
 

--- a/examples/AD9851_demo_float/AD9851_demo_float.ino
+++ b/examples/AD9851_demo_float/AD9851_demo_float.ino
@@ -8,7 +8,8 @@
 #include "AD985X.h"
 
 
-AD9851 freqGen(10, 9, 8, 7, 6); 
+AD9851 freqGen(10, 9, 8, 7, 6);  //  SW SPI
+//  AD9851 freqGen(10, 9, 8, &SPI, 6);  //  HW SPI
 
 uint32_t freq = 0;
 uint32_t prev = 0;
@@ -22,7 +23,7 @@ void setup()
   Serial.print("AD985X_LIB_VERSION: \t");
   Serial.println(AD985X_LIB_VERSION);
 
-  SPI.begin();
+  // SPI.begin();  //  HW SPI
 
   freqGen.begin();
   freqGen.powerUp();

--- a/examples/AD9851_manual_update/AD9851_manual_update.ino
+++ b/examples/AD9851_manual_update/AD9851_manual_update.ino
@@ -8,7 +8,8 @@
 #include "AD985X.h"
 
 
-AD9851 freqGen(10, 9, 8, 7, 6);
+AD9851 freqGen(10, 9, 8, 7, 6);  //  SW SPI
+//  AD9851 freqGen(10, 9, 8, &SPI, 6);  //  HW SPI
 
 uint32_t freq    = 0;
 uint32_t maxFreq = 2000000UL;
@@ -25,7 +26,7 @@ void setup()
   Serial.print("AD985X_LIB_VERSION: \t");
   Serial.println(AD985X_LIB_VERSION);
 
-  SPI.begin();
+  // SPI.begin();  //  HW SPI
 
   freqGen.begin();
   freqGen.powerUp();

--- a/examples/AD9851_six_potmeter/AD9851_six_potmeter.ino
+++ b/examples/AD9851_six_potmeter/AD9851_six_potmeter.ino
@@ -8,7 +8,8 @@
 #include "AD985X.h"
 
 
-AD9851 freqGen(10, 9, 8, 7, 6); 
+AD9851 freqGen(10, 9, 8, 7, 6);  //  SW SPI
+//  AD9851 freqGen(10, 9, 8, &SPI, 6);  //  HW SPI
 
 
 void setup()
@@ -18,7 +19,7 @@ void setup()
   Serial.print("AD985X_LIB_VERSION: \t");
   Serial.println(AD985X_LIB_VERSION);
 
-  SPI.begin();
+  // SPI.begin();  //  HW SPI
 
   freqGen.begin();
 }

--- a/examples/AD9851_sweeper/AD9851_sweeper.ino
+++ b/examples/AD9851_sweeper/AD9851_sweeper.ino
@@ -8,7 +8,8 @@
 #include "AD985X.h"
 
 
-AD9851 freqGen(10, 9, 8, 7, 6);
+AD9851 freqGen(10, 9, 8, 7, 6);  //  SW SPI
+//  AD9851 freqGen(10, 9, 8, &SPI, 6);  //  HW SPI
 
 uint32_t freq    = 0;
 uint32_t maxFreq = 2000000UL;
@@ -23,7 +24,7 @@ void setup()
   Serial.print("AD985X_LIB_VERSION: \t");
   Serial.println(AD985X_LIB_VERSION);
 
-  SPI.begin();
+  // SPI.begin();  //  HW SPI
 
   freqGen.begin();
   freqGen.powerUp();

--- a/examples/AD985X_array/AD985X_array.ino
+++ b/examples/AD985X_array/AD985X_array.ino
@@ -57,7 +57,7 @@ void setup()
   Serial.print("AD985X_LIB_VERSION: \t");
   Serial.println(AD985X_LIB_VERSION);
 
-  SPI.begin();
+  // SPI.begin();  //  HW SPI
 
   //  initialize three devices
   for (int i = 0; i < 3; i++)


### PR DESCRIPTION
Hi. The software SPI doesn't work in v0.5.0. I found the bug and did these changes:
+ Set the data pin of software SPI
+ Comment out SPI.begin() in the examples with software SPI
+ Add comments about hardware SPI usage in some examples