### PR TITLE
Fix the mask bits

### DIFF
--- a/AD985X.cpp
+++ b/AD985X.cpp
@@ -161,7 +161,7 @@ void AD9850::writeData()
     data >>= 8;
     _mySPI->transfer(data & 0xFF);
     _mySPI->transfer(data >> 8);
-    _mySPI->transfer(_config & 0xFC);  //  mask factory test bit
+    _mySPI->transfer(_config & 0xFD);  //  mask factory test bit
     _mySPI->endTransaction();
   }
   else
@@ -172,7 +172,7 @@ void AD9850::writeData()
     data >>= 8;
     swSPI_transfer(data & 0xFF);
     swSPI_transfer(data >> 8);
-    swSPI_transfer(_config & 0xFC);  //  mask factory test bit
+    swSPI_transfer(_config & 0xFD);  //  mask factory test bit
   }
   digitalWrite(_select, LOW);
 


### PR DESCRIPTION
The mask bits `0xFC` only works for AD9850. For AD9851, Masking the `_config` with `0xFC` forces the chip to disable the PLL, which discards the actual last bit in `_config`. Plus, `0xFD` also works for AD9850 because the last bit of `_config` is initialized to 0 in `begin()`, so it's impossible to set the last bit of `_config` to 1 in `AD9850::xxx()`

For AD9850:
![图片](https://github.com/RobTillaart/AD985X/assets/62299611/012d013f-43cb-41c1-9724-dbe17ddcde7a)

For AD9851:
![图片](https://github.com/RobTillaart/AD985X/assets/62299611/9b2e8731-8c3b-4ea8-bd69-2c704ccdd148)
