### PR TITLE
Slave Select optional + Remove clock requirement on HW-SPI

### DIFF
--- a/AD985X.h
+++ b/AD985X.h
@@ -42,7 +42,7 @@ class AD9850
 public:
   //  HARDWARE SPI
   //  spiClock needed for RESET(). TODO: nicer solution?
-  AD9850(uint8_t slaveSelect, uint8_t resetPin, uint8_t FQUDPin, __SPI_CLASS__ * mySPI, uint8_t spiClock);
+  AD9850(uint8_t slaveSelect, uint8_t resetPin, uint8_t FQUDPin, __SPI_CLASS__ * mySPI);
   //  SOFTWARE SPI
   AD9850(uint8_t slaveSelect, uint8_t resetPin, uint8_t FQUDPin, uint8_t spiData, uint8_t spiClock);
 
@@ -125,7 +125,7 @@ class AD9851 : public AD9850
 public:
   //  HARDWARE SPI
   //  spiClock needed for RESET(). TODO: nicer solution?
-  AD9851(uint8_t slaveSelect, uint8_t resetPin, uint8_t FQUDPin, __SPI_CLASS__ * mySPI, uint8_t spiClock);
+  AD9851(uint8_t slaveSelect, uint8_t resetPin, uint8_t FQUDPin, __SPI_CLASS__ * mySPI);
   //  SOFTWARE SPI
   AD9851(uint8_t slaveSelect, uint8_t resetPin, uint8_t FQUDPin, uint8_t spiData, uint8_t spiClock);
 


### PR DESCRIPTION
In cases where no slave select functionality is wanted, an invalid pin number higher than 50 may be chosen. 
In these cases, no slave select pin will be occupied. 

For the hardware SPI the clock PIN was required for the reset function even for the hardware SPI. This update implements a reset function which does use a empty hardware spi push as replacement for the hardware spi. The software spi is unchanged and handled separately.